### PR TITLE
增加对 webpack5 的支持

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -25,7 +25,7 @@ module.exports = class Handler {
         var outputName = getFileName(this.options.fileName, output)
 
         // Add Webpack5 Support
-        if (webpack.version[0] === '5') {
+        if (webpack.version[0] >= '5') {
             compilation.emitAsset(
                 outputName,
                 new webpack.sources.RawSource(output)
@@ -64,7 +64,7 @@ module.exports = class Handler {
             var content = source.source().replace(/(\<|\\x3C)script/i, m => '<script>' + configJs + '</script>\n' + m);
 
             // Add Webpack5 Support
-            if (webpack.version[0] === '5') {
+            if (webpack.version[0] >= '5') {
                 compilation.emitAsset(
                   name,
                   new webpack.sources.RawSource(content)

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class ThemeColorReplacer {
             WP_THEME_CONFIG: JSON.stringify(this.handler.options.configVar)
         }).apply(compiler)
         
-        if (webpack.version[0] === '5') {
+        if (webpack.version[0] >= '5') {
               // Add Webpack5 Support
               compiler.hooks.thisCompilation.tap('ThemeColorReplacer', (compilation) => {
                   compilation.hooks.processAssets.tapAsync(

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,26 @@ class ThemeColorReplacer {
         new webpack.DefinePlugin({
             WP_THEME_CONFIG: JSON.stringify(this.handler.options.configVar)
         }).apply(compiler)
-        this.getBinder(compiler, 'emit')((compilation, callback) => {
-            this.handler.handle(compilation)
-            callback()
-        });
+        
+        if (webpack.version[0] === '5') {
+              // Add Webpack5 Support
+              compiler.hooks.thisCompilation.tap('ThemeColorReplacer', (compilation) => {
+                  compilation.hooks.processAssets.tapAsync(
+                      {
+                        name: 'ThemeColorReplacer',
+                        stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+                      },
+                      (compilationAssets, callback) => {        
+                        this.handler.handle(compilation)
+                        callback()
+                      });
+              });
+        } else {
+              this.getBinder(compiler, 'emit')((compilation, callback) => {
+                  this.handler.handle(compilation)
+                  callback()
+              });
+        }
     }
 }
 


### PR DESCRIPTION
当 webpack 版本 >= 5 时，使用 compilation.hooks.processAssets 和 compilation.emitAsset Api 以实现 Webpack5 的支持