### PR TITLE
fix: 修复esm和cjs混用同一个入口文件导致的编译bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.3",
   "description": "A webpack plugin designed to dynamicly change the theme colors at runtime. 实现运行时快速动态替换主题色的webpack插件. ",
   "main": "src/index.js",
+  "module": "client/index.js",
   "scripts": {
     "test": "node test/nodejs/index.js && npm run webpack",
     "webpack": "node test/webpack/webpack.js",


### PR DESCRIPTION
src/index.js里面新引入了webpack模块，本身已经不适合作为cjs和esm的共用入口文件了，应当区分开。 如果前端直接通过import引入入口文件，则会因为该webpack模块导致编译错误。