### PR TITLE
在启用webpack5的持久化缓存时,由于assetSource._source可能是一个function导致后续处理报错

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -111,7 +111,7 @@ module.exports = class Handler {
         var CachedSource = wpSources.CachedSource
         var configJs = this.getConfigJs(outputName, cssCode)
         if (assetSource instanceof CachedSource) { // CachedSource没有node方法，会报错
-            return new CachedSource(concatSrc(assetSource._source || assetSource.source(), configJs))
+            return new CachedSource(concatSrc(((typeof assetSource._source === 'function') ? assetSource._source() : assetSource._source) || assetSource.source(), configJs))
         }
         return concatSrc(assetSource, configJs)
 


### PR DESCRIPTION
fix #118 